### PR TITLE
Feature/ssm param for rss urls instead of hard-coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Functional:
 	* Various AWS SSM parameters denoting:
 		|Parameter|Description|
 		|---------|-----------|
-		|/RssEmailerZohoNotifier/accountId|Zoho Mail API account ID|
+		|/RssEmailerZohoNotifier/accountId|Zoho Mail API account ID for sending HTML-formatted emails via Zoho|
 		|/RssEmailerZohoNotifier/clientId|Zoho Mail API client ID|
 		|/RssEmailerZohoNotifier/clientSecret|Zoho Mail API client secret|
 		|/RssEmailerZohoNotifier/destinationEmail|Email address to send the notification to|
 		|/RssEmailerZohoNotifier/fromEmail|From email address. Must be a valid email address in the Zoho account|
 		|/RssEmailerZohoNotifier/emailSubject|Email subject to use in the notification|
+		|/RssEmailerZohoNotifier/rssUrls|JSON list of RSS URLs to check, e.g. `["https://www.keycloak.org/rss.xml", "https://aws.amazon.com/blogs/aws/feed/"]`|
 
 		* Where `RssEmailerZohoNotifier` is the SSM parameter's path prefix. This is passed as an environment variable to the Lambda function. It should start with `/`
 		* Example AWS CLI to create the parameters:

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -16,10 +16,11 @@ lint = true
 [default.deploy.parameters]
 capabilities = "CAPABILITY_IAM"
 confirm_changeset = true
-resolve_s3 = true
-s3_prefix = "SimpleRssMailer"
 region = "us-east-1"
 image_repositories = []
+parameter_overrides = "RssUrlsSsmParameter=arn:aws:ssm:us-east-1:123456789012:parameter/RssEmailerZohoNotifier/rssUrls"
+resolve_s3 = true
+s3_prefix = "SimpleRssMailer"
 tags = "Application=SimpleRssMailer"
 
 [default.package.parameters]

--- a/template.yaml
+++ b/template.yaml
@@ -3,6 +3,11 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   Deploys Simple Rss Mailer to AWS
 
+Parameters:
+  RssUrlsSsmParameter:
+    Type: AWS::SSM::Parameter::Name
+    Description: SSM parameter that defines the RSS URLs to check as a JSON array, e.g. ["url1", "url2"]
+
 Resources:
   LambdaFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -26,7 +31,7 @@ Resources:
             FlexibleTimeWindow:
               MaximumWindowInMinutes: 15
               Mode: FLEXIBLE
-            Input: '{"rss_urls": ["https://www.keycloak.org/rss.xml"]}' # RSS feeds to check. TODO this should be a SSM parameter or something
+            Input: !Sub '{"rss_urls": ["${RssUrlsSsmParameter}"]}' # RSS URL feeds to check. Or if the first URL is a AWS SSM parameter store ARN, retrieve RSS URLs from there instead
             ScheduleExpression: cron(0 19 * * ? *) # Everyday at 7PM UTC
       LoggingConfig:
         LogFormat: JSON


### PR DESCRIPTION
If the first RSS URL is actually the ARN of an AWS SSM Parameter, look up that parameters values for the RSS URLs instead. This allows the RSS URLs to be changed without having to do CloudFormation redeploys.